### PR TITLE
Allow `filepath` of type `pathib.Path` in constructor.

### DIFF
--- a/fontbro/font.py
+++ b/fontbro/font.py
@@ -5,6 +5,7 @@ import re
 import sys
 import tempfile
 from curses import ascii
+from pathlib import Path
 
 import fsutil
 from fontTools import unicodedata
@@ -215,12 +216,12 @@ class Font:
         self._kwargs = None
         self._ttfont = None
 
-        if isinstance(filepath, str):
-            self._init_with_filepath(filepath, **kwargs)
+        if isinstance(filepath, (Path, str)):
+            self._init_with_filepath(str(filepath), **kwargs)
         else:
             filepath_type = type(filepath).__name__
             raise ValueError(
-                f"Invalid filepath type: expected str, found {filepath_type!r}."
+                f"Invalid filepath type: expected pathlib.Path or str, found {filepath_type!r}."
             )
 
     def _init_with_filepath(self, filepath, **kwargs):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,7 +1,9 @@
-# from fontTools.ttLib import TTFont
+from pathlib import Path
 
 from fontbro import Font
 from tests import AbstractTestCase
+
+# from fontTools.ttLib import TTFont
 
 
 class InitTestCase(AbstractTestCase):
@@ -11,6 +13,11 @@ class InitTestCase(AbstractTestCase):
 
     def test_init_with_filepath(self):
         filepath = self._get_font_path("/Noto_Sans_TC/NotoSansTC-Regular.otf")
+        Font(filepath=filepath)
+
+    def test_init_with_filepath_using_pathlib_path(self):
+        dirpath = Path(__file__).parent / Path("fonts")
+        filepath = dirpath / Path("Noto_Sans_TC/NotoSansTC-Regular.otf")
         Font(filepath=filepath)
 
     def test_init_with_filepath_but_invalid_font_file(self):


### PR DESCRIPTION
Fix #83 