### PR TITLE
Add possibility to create static instance by using `style_name` instead of `coordinates`.

### DIFF
--- a/fontbro/font.py
+++ b/fontbro/font.py
@@ -1291,7 +1291,7 @@ class Font:
         # instantiate the sliced variable font
         instancer.instantiateVariableFont(font, coordinates, inplace=True, **options)
 
-    def to_static(self, coordinates=None, **options):
+    def to_static(self, coordinates=None, style_name=None, **options):
         """
         Converts the variable font to a static one pinning
         the variable axes at the given coordinates.
@@ -1300,6 +1300,8 @@ class Font:
 
         :param coordinates: The coordinates, eg. {'wght':500, 'ital':50}
         :type coordinates: dict or None
+        :param style_name: The existing instance style name, eg. 'Black'
+        :type style_name: str or None
         :param options: The options for the fontTools.varLib.instancer
         :type options: dictionary
 
@@ -1310,6 +1312,22 @@ class Font:
             raise TypeError("Only a variable font can be made static.")
 
         font = self.get_ttfont()
+
+        # take coordinates from instance with specified style name
+        if style_name:
+            if coordinates:
+                raise ValueError(
+                    "Invalid arguments: 'coordinates' and 'style_name' are mutually exclusive."
+                )
+            instances = self.get_variable_instances()
+            for instance in instances:
+                if slugify(instance["style_name"]) == slugify(style_name):
+                    coordinates = instance["coordinates"].copy()
+                    break
+            if not coordinates:
+                raise ValueError(
+                    f"Invalid style name: instance with style name {style_name!r} not found."
+                )
 
         # make coordinates more friendly by using default axis values by default
         coordinates = coordinates or {}

--- a/tests/test_instantiation.py
+++ b/tests/test_instantiation.py
@@ -44,6 +44,22 @@ class InstantiationTestCase(AbstractTestCase):
         with self.assertRaises(ValueError):
             font.to_static(coordinates={"wght": [100, 400]})
 
+    def test_to_static_with_style_name(self):
+        font = self._get_variable_font()
+        font.to_static(style_name="Black")
+        self.assertTrue(font.is_static())
+        self.assertEqual(font.get_weight()["value"], 900)
+
+    def test_to_static_with_style_name_and_coordinates(self):
+        font = self._get_variable_font()
+        with self.assertRaises(ValueError):
+            font.to_static(coordinates={"wght": [100, 400]}, style_name="ExtraBlack")
+
+    def test_to_static_with_style_name_invalid(self):
+        font = self._get_variable_font()
+        with self.assertRaises(ValueError):
+            font.to_static(style_name="ExtraBlack")
+
     def test_to_sliced_variable_with_static_font(self):
         font = self._get_static_font()
         with self.assertRaises(TypeError):


### PR DESCRIPTION
Fix #82 